### PR TITLE
Readme: typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ with characters, such as `lower` and `upper`.
 ```clojure 
 (defn check-roman [char]
   (match (Character.from-char char)
-    (Invalid) flase
+    (Invalid) false
     _ true))
 ```
 


### PR DESCRIPTION
This PR fixes a typo in a code example from `flase` to `false`.

Also: does flase rhyme with blasé or with base?

Cheers